### PR TITLE
feat: 統計ダッシュボードとサンプル質問サジェストを追加

### DIFF
--- a/backend/routers/documents.py
+++ b/backend/routers/documents.py
@@ -2,13 +2,13 @@ import os
 from pathlib import Path
 
 from fastapi import APIRouter, Depends, HTTPException, UploadFile
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from config import settings
 from database import get_db
 from models import Document
-from schemas import DocumentResponse
+from schemas import DocumentResponse, DocumentStats, FileTypeCount
 from services.document_processor import extract_text, split_into_chunks
 from services.embedding_service import generate_embeddings
 from services.vector_store import add_chunks, delete_by_document_id
@@ -86,6 +86,38 @@ async def list_documents(db: AsyncSession = Depends(get_db)):
         select(Document).order_by(Document.uploaded_at.desc())
     )
     return result.scalars().all()
+
+
+@router.get("/stats", response_model=DocumentStats)
+async def document_stats(db: AsyncSession = Depends(get_db)):
+    """文書の統計情報を取得する"""
+    # 全体集計
+    result = await db.execute(
+        select(
+            func.count(Document.id),
+            func.coalesce(func.sum(Document.chunk_count), 0),
+            func.coalesce(func.sum(Document.file_size), 0),
+        ).where(Document.status == "ready")
+    )
+    row = result.one()
+    total_documents, total_chunks, total_size = int(row[0]), int(row[1]), int(row[2])
+
+    # ファイル種別ごとの件数
+    type_result = await db.execute(
+        select(Document.file_type, func.count(Document.id))
+        .where(Document.status == "ready")
+        .group_by(Document.file_type)
+    )
+    file_type_breakdown = [
+        FileTypeCount(file_type=ft, count=cnt) for ft, cnt in type_result.all()
+    ]
+
+    return DocumentStats(
+        total_documents=total_documents,
+        total_chunks=total_chunks,
+        total_size=total_size,
+        file_type_breakdown=file_type_breakdown,
+    )
 
 
 @router.delete("/{document_id}")

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -29,3 +29,15 @@ class ChatResponse(BaseModel):
     answer: str
     sources: list[SourceInfo]
     confidence: str  # "high" | "medium" | "low" | "unknown"
+
+
+class FileTypeCount(BaseModel):
+    file_type: str
+    count: int
+
+
+class DocumentStats(BaseModel):
+    total_documents: int
+    total_chunks: int
+    total_size: int
+    file_type_breakdown: list[FileTypeCount]

--- a/frontend/src/app/admin/page.tsx
+++ b/frontend/src/app/admin/page.tsx
@@ -3,32 +3,45 @@
 import { useCallback, useEffect, useState } from "react";
 import FileUpload from "@/components/FileUpload";
 import DocumentList from "@/components/DocumentList";
-import { listDocuments, type DocumentInfo } from "@/lib/api";
+import StatsCards from "@/components/StatsCards";
+import {
+  listDocuments,
+  fetchDocumentStats,
+  type DocumentInfo,
+  type DocumentStats,
+} from "@/lib/api";
 
 export default function AdminPage() {
   const [documents, setDocuments] = useState<DocumentInfo[]>([]);
+  const [stats, setStats] = useState<DocumentStats | null>(null);
   const [loading, setLoading] = useState(true);
 
-  const fetchDocuments = useCallback(async () => {
+  const fetchAll = useCallback(async () => {
     try {
-      const docs = await listDocuments();
+      const [docs, s] = await Promise.all([
+        listDocuments(),
+        fetchDocumentStats(),
+      ]);
       setDocuments(docs);
+      setStats(s);
     } catch {
-      console.error("文書一覧の取得に失敗しました");
+      console.error("データの取得に失敗しました");
     } finally {
       setLoading(false);
     }
   }, []);
 
   useEffect(() => {
-    fetchDocuments();
-  }, [fetchDocuments]);
+    fetchAll();
+  }, [fetchAll]);
 
   return (
     <div>
       <h1 className="text-2xl font-bold text-gray-800 mb-6">文書管理</h1>
 
-      <FileUpload onUploadComplete={fetchDocuments} />
+      {stats && <StatsCards stats={stats} />}
+
+      <FileUpload onUploadComplete={fetchAll} />
 
       <div className="bg-white rounded-lg border border-gray-200 p-4">
         <h2 className="text-lg font-semibold text-gray-700 mb-4">
@@ -42,7 +55,7 @@ export default function AdminPage() {
             読み込み中...
           </p>
         ) : (
-          <DocumentList documents={documents} onDelete={fetchDocuments} />
+          <DocumentList documents={documents} onDelete={fetchAll} />
         )}
       </div>
     </div>

--- a/frontend/src/app/chat/page.tsx
+++ b/frontend/src/app/chat/page.tsx
@@ -3,6 +3,7 @@
 import { useRef, useState } from "react";
 import ChatInput from "@/components/ChatInput";
 import ChatMessage from "@/components/ChatMessage";
+import SuggestedQuestions from "@/components/SuggestedQuestions";
 import { sendChat, type ChatResponse } from "@/lib/api";
 
 interface Message {
@@ -49,25 +50,26 @@ export default function ChatPage() {
       </h1>
 
       <div className="flex-1 overflow-y-auto bg-white rounded-lg border border-gray-200 p-4 mb-4">
-        {messages.length === 0 && (
-          <div className="flex items-center justify-center h-full text-gray-400">
-            <p>質問を入力すると、社内文書から根拠付きで回答します</p>
-          </div>
-        )}
-        {messages.map((msg, i) => (
-          <ChatMessage
-            key={i}
-            role={msg.role}
-            content={msg.content}
-            response={msg.response}
-          />
-        ))}
-        {loading && (
-          <div className="flex justify-start mb-4">
-            <div className="bg-white border border-gray-200 rounded-lg px-4 py-3 text-gray-500">
-              <span className="animate-pulse">検索・回答を生成中...</span>
-            </div>
-          </div>
+        {messages.length === 0 ? (
+          <SuggestedQuestions onSelect={handleSend} />
+        ) : (
+          <>
+            {messages.map((msg, i) => (
+              <ChatMessage
+                key={i}
+                role={msg.role}
+                content={msg.content}
+                response={msg.response}
+              />
+            ))}
+            {loading && (
+              <div className="flex justify-start mb-4">
+                <div className="bg-white border border-gray-200 rounded-lg px-4 py-3 text-gray-500">
+                  <span className="animate-pulse">検索・回答を生成中...</span>
+                </div>
+              </div>
+            )}
+          </>
         )}
         <div ref={bottomRef} />
       </div>

--- a/frontend/src/components/StatsCards.tsx
+++ b/frontend/src/components/StatsCards.tsx
@@ -1,0 +1,53 @@
+import type { DocumentStats } from "@/lib/api";
+
+interface StatsCardsProps {
+  stats: DocumentStats;
+}
+
+function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+export default function StatsCards({ stats }: StatsCardsProps) {
+  return (
+    <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
+      <div className="bg-white rounded-lg border border-gray-200 p-4">
+        <p className="text-sm text-gray-500">登録文書数</p>
+        <p className="text-2xl font-bold text-gray-800">
+          {stats.total_documents}
+        </p>
+      </div>
+      <div className="bg-white rounded-lg border border-gray-200 p-4">
+        <p className="text-sm text-gray-500">総チャンク数</p>
+        <p className="text-2xl font-bold text-gray-800">
+          {stats.total_chunks}
+        </p>
+      </div>
+      <div className="bg-white rounded-lg border border-gray-200 p-4">
+        <p className="text-sm text-gray-500">総データ量</p>
+        <p className="text-2xl font-bold text-gray-800">
+          {formatSize(stats.total_size)}
+        </p>
+      </div>
+      <div className="bg-white rounded-lg border border-gray-200 p-4">
+        <p className="text-sm text-gray-500">ファイル種別</p>
+        <div className="flex flex-wrap gap-1 mt-1">
+          {stats.file_type_breakdown.length === 0 ? (
+            <span className="text-sm text-gray-400">-</span>
+          ) : (
+            stats.file_type_breakdown.map((ft) => (
+              <span
+                key={ft.file_type}
+                className="px-2 py-0.5 bg-gray-100 text-gray-600 rounded text-xs font-medium uppercase"
+              >
+                {ft.file_type}: {ft.count}
+              </span>
+            ))
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/SuggestedQuestions.tsx
+++ b/frontend/src/components/SuggestedQuestions.tsx
@@ -1,0 +1,40 @@
+interface SuggestedQuestionsProps {
+  onSelect: (question: string) => void;
+}
+
+const SUGGESTIONS = [
+  "有給休暇の申請方法を教えてください",
+  "リモートワークのルールは？",
+  "経費精算の手順を教えてください",
+  "パスワードを忘れた場合はどうすればいい？",
+  "VPN接続ができないときの対処法は？",
+  "通勤手当の上限はいくらですか？",
+];
+
+export default function SuggestedQuestions({
+  onSelect,
+}: SuggestedQuestionsProps) {
+  return (
+    <div className="flex flex-col items-center justify-center h-full gap-6">
+      <div className="text-center">
+        <p className="text-gray-400 mb-1">
+          質問を入力すると、社内文書から根拠付きで回答します
+        </p>
+        <p className="text-sm text-gray-300">
+          または以下のサンプル質問をお試しください
+        </p>
+      </div>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 max-w-lg w-full">
+        {SUGGESTIONS.map((q) => (
+          <button
+            key={q}
+            onClick={() => onSelect(q)}
+            className="text-left px-3 py-2 text-sm text-gray-600 bg-gray-50 border border-gray-200 rounded-lg hover:bg-blue-50 hover:border-blue-300 hover:text-blue-700 transition-colors"
+          >
+            {q}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -47,6 +47,24 @@ export async function deleteDocument(id: number): Promise<void> {
   if (!res.ok) throw new Error("削除に失敗しました");
 }
 
+export interface FileTypeCount {
+  file_type: string;
+  count: number;
+}
+
+export interface DocumentStats {
+  total_documents: number;
+  total_chunks: number;
+  total_size: number;
+  file_type_breakdown: FileTypeCount[];
+}
+
+export async function fetchDocumentStats(): Promise<DocumentStats> {
+  const res = await fetch(`${API_BASE}/documents/stats`);
+  if (!res.ok) throw new Error("統計情報の取得に失敗しました");
+  return res.json();
+}
+
 export async function sendChat(question: string): Promise<ChatResponse> {
   const res = await fetch(`${API_BASE}/chat`, {
     method: "POST",


### PR DESCRIPTION
## Summary
- 管理画面の上部に統計ダッシュボード（登録文書数・総チャンク数・総データ量・ファイル種別内訳）を追加
- チャット画面の初期状態でサンプル質問ボタンを表示し、クリックで即質問できる機能を追加
- `GET /api/documents/stats` 統計APIを新設

## Test plan
- [ ] バックエンドを起動し `GET /api/documents/stats` が正常にレスポンスを返すことを確認
- [ ] 管理画面で統計カード4枚が表示されることを確認
- [ ] 文書アップロード・削除後に統計値が更新されることを確認
- [ ] チャット画面の初期状態でサンプル質問6つが表示されることを確認
- [ ] サンプル質問クリックで質問が送信され、回答後にサジェストが非表示になることを確認

https://claude.ai/code/session_01DbrKWxTnEr59dhEgdDTfxh