### PR TITLE
エラーハンドリング・バリデーション・ロギングの改善

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,3 +1,4 @@
+import logging
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
@@ -6,11 +7,20 @@ from fastapi.middleware.cors import CORSMiddleware
 from database import init_db
 from routers import chat, documents
 
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+)
+logger = logging.getLogger(__name__)
+
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    logger.info("アプリケーションを起動中...")
     await init_db()
+    logger.info("データベース初期化完了")
     yield
+    logger.info("アプリケーションをシャットダウン中...")
 
 
 app = FastAPI(

--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -1,7 +1,11 @@
-from fastapi import APIRouter
+import logging
+
+from fastapi import APIRouter, HTTPException
 
 from schemas import ChatRequest, ChatResponse
 from services.rag_service import ask
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/chat", tags=["chat"])
 
@@ -15,4 +19,11 @@ async def chat(request: ChatRequest):
             sources=[],
             confidence="unknown",
         )
-    return ask(request.question)
+    try:
+        return ask(request.question)
+    except Exception as e:
+        logger.error("チャット処理中にエラーが発生: %s", e, exc_info=True)
+        raise HTTPException(
+            status_code=503,
+            detail="回答の生成に失敗しました。しばらくしてから再度お試しください。",
+        )

--- a/backend/routers/documents.py
+++ b/backend/routers/documents.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from pathlib import Path
 
@@ -6,6 +7,10 @@ from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from config import settings
+
+logger = logging.getLogger(__name__)
+
+MAX_FILE_SIZE = 10 * 1024 * 1024  # 10MB
 from database import get_db
 from models import Document
 from schemas import DocumentResponse, DocumentStats, FileTypeCount
@@ -33,6 +38,12 @@ async def upload_document(file: UploadFile, db: AsyncSession = Depends(get_db)):
 
     file_bytes = await file.read()
     file_size = len(file_bytes)
+
+    if file_size > MAX_FILE_SIZE:
+        raise HTTPException(
+            status_code=400,
+            detail=f"ファイルサイズが上限（{MAX_FILE_SIZE // (1024 * 1024)}MB）を超えています",
+        )
 
     # DBにメタデータ保存
     doc = Document(
@@ -72,6 +83,7 @@ async def upload_document(file: UploadFile, db: AsyncSession = Depends(get_db)):
         await db.refresh(doc)
 
     except Exception as e:
+        logger.error("文書処理に失敗 (doc_id=%s): %s", doc.id, e, exc_info=True)
         doc.status = "error"
         await db.commit()
         raise HTTPException(status_code=500, detail=f"処理に失敗しました: {str(e)}")

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,4 +1,18 @@
 const API_BASE = "/api";
+const DEFAULT_TIMEOUT_MS = 30_000;
+const CHAT_TIMEOUT_MS = 60_000;
+
+function fetchWithTimeout(
+  url: string,
+  options: RequestInit = {},
+  timeoutMs: number = DEFAULT_TIMEOUT_MS,
+): Promise<Response> {
+  const controller = new AbortController();
+  const id = setTimeout(() => controller.abort(), timeoutMs);
+  return fetch(url, { ...options, signal: controller.signal }).finally(() =>
+    clearTimeout(id),
+  );
+}
 
 export interface DocumentInfo {
   id: number;
@@ -25,7 +39,7 @@ export interface ChatResponse {
 export async function uploadDocument(file: File): Promise<DocumentInfo> {
   const formData = new FormData();
   formData.append("file", file);
-  const res = await fetch(`${API_BASE}/documents/upload`, {
+  const res = await fetchWithTimeout(`${API_BASE}/documents/upload`, {
     method: "POST",
     body: formData,
   });
@@ -37,13 +51,13 @@ export async function uploadDocument(file: File): Promise<DocumentInfo> {
 }
 
 export async function listDocuments(): Promise<DocumentInfo[]> {
-  const res = await fetch(`${API_BASE}/documents`);
+  const res = await fetchWithTimeout(`${API_BASE}/documents`);
   if (!res.ok) throw new Error("文書一覧の取得に失敗しました");
   return res.json();
 }
 
 export async function deleteDocument(id: number): Promise<void> {
-  const res = await fetch(`${API_BASE}/documents/${id}`, { method: "DELETE" });
+  const res = await fetchWithTimeout(`${API_BASE}/documents/${id}`, { method: "DELETE" });
   if (!res.ok) throw new Error("削除に失敗しました");
 }
 
@@ -60,17 +74,24 @@ export interface DocumentStats {
 }
 
 export async function fetchDocumentStats(): Promise<DocumentStats> {
-  const res = await fetch(`${API_BASE}/documents/stats`);
+  const res = await fetchWithTimeout(`${API_BASE}/documents/stats`);
   if (!res.ok) throw new Error("統計情報の取得に失敗しました");
   return res.json();
 }
 
 export async function sendChat(question: string): Promise<ChatResponse> {
-  const res = await fetch(`${API_BASE}/chat`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ question }),
-  });
-  if (!res.ok) throw new Error("回答の取得に失敗しました");
+  const res = await fetchWithTimeout(
+    `${API_BASE}/chat`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ question }),
+    },
+    CHAT_TIMEOUT_MS,
+  );
+  if (!res.ok) {
+    const err = await res.json().catch(() => null);
+    throw new Error(err?.detail || "回答の取得に失敗しました");
+  }
   return res.json();
 }


### PR DESCRIPTION
## Summary\n\n- **チャットAPIにエラーハンドリング追加**: OpenAI API障害時に500ではなく503と適切なメッセージを返すように改善\n- **ファイルサイズ制限追加**: アップロード上限を10MBに設定し、大きすぎるファイルによるメモリ枯渇を防止\n- **フロントエンドAPIにタイムアウト追加**: 通常リクエスト30秒、チャットリクエスト60秒のタイムアウトを設定し、ハング防止\n- **バックエンドにロギング導入**: `logging`モジュールで起動・エラー時のログを出力し、デバッグを容易に\n\n## 変更ファイル\n\n| ファイル | 変更内容 |\n|---|---|\n| `backend/main.py` | logging設定追加、ライフサイクルログ出力 |\n| `backend/routers/chat.py` | try-catch + HTTP 503レスポンス |\n| `backend/routers/documents.py` | 10MBファイルサイズ制限、エラーログ出力 |\n| `frontend/src/lib/api.ts` | `fetchWithTimeout`ヘルパー追加、全API呼び出しにタイムアウト適用 |\n\n## Test plan\n\n- [ ] チャットAPIでOpenAI APIキーが無効な場合、503エラーと日本語メッセージが返ることを確認\n- [ ] 10MBを超えるファイルをアップロードし、400エラーが返ることを確認\n- [ ] 10MB以下のファイルが正常にアップロードできることを確認\n- [ ] フロントエンドでバックエンドを停止した状態でリクエストし、タイムアウトが発生することを確認\n- [ ] バックエンド起動時にログが出力されることを確認\n\nhttps://claude.ai/code/session_014M9wSyVGfKPFUDwLNb8Aah