### PR TITLE
CI/CDの整備: GitHub Actions ワークフローを追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI - Backend Tests
+
+on:
+  push:
+    branches: [ main, feat/**, fix/** ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    name: Python Backend Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Cache pip dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('backend/requirements.txt', 'backend/requirements-test.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install dependencies
+        working-directory: backend
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -r requirements-test.txt
+
+      - name: Lint with flake8
+        working-directory: backend
+        run: |
+          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+          flake8 . --count --max-line-length=120 --statistics --exclude=__pycache__,.git
+
+      - name: Run tests with pytest
+        working-directory: backend
+        run: |
+          pytest tests/ -v --tb=short

--- a/backend/requirements-test.txt
+++ b/backend/requirements-test.txt
@@ -1,0 +1,4 @@
+pytest==8.3.4
+pytest-asyncio==0.24.0
+httpx==0.28.1
+flake8==7.1.1


### PR DESCRIPTION
## 概要

Issue #9 に対応し、GitHub Actions CI ワークフローを追加します。

## 変更内容

- `.github/workflows/ci.yml` を追加
  - Python 3.11 環境でのテスト実行
  - `push` / `pull_request` トリガー対応
  - `flake8` によるLintチェック
  - `pytest tests/ -v` によるバックエンドテスト自動実行
- `backend/requirements-test.txt` を追加
  - pytest, pytest-asyncio, httpx, flake8

## テスト結果の分析

- `test_schemas.py`: pydantic バリデーションのみ、外部サービス不要
- `test_document_processor.py`: `unittest.mock` を使用してsettingsをモック、外部サービス不要
- 実際の認証情報なしでCI環境での実行が可能

## テスト計画

- [ ] ワークフローが正常にトリガーされることを確認
- [ ] pytest テストがすべてパスすることを確認
- [ ] flake8 Lintチェックが通ることを確認

Closes #9