### PR TITLE
flake8 lintエラーを修正

### DIFF
--- a/backend/services/document_processor.py
+++ b/backend/services/document_processor.py
@@ -74,7 +74,7 @@ def split_into_chunks(text: str) -> list[str]:
             # 段落自体がchunk_sizeを超える場合は文字数で分割
             if len(para) > chunk_size:
                 for i in range(0, len(para), chunk_size - overlap):
-                    chunks.append(para[i : i + chunk_size].strip())
+                    chunks.append(para[i:i + chunk_size].strip())
                 current_chunk = ""
             else:
                 current_chunk = para

--- a/backend/tests/test_chat_router.py
+++ b/backend/tests/test_chat_router.py
@@ -5,13 +5,13 @@ import os
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
-import pytest
-from unittest.mock import patch, MagicMock
-from fastapi.testclient import TestClient
-from fastapi import FastAPI
+import pytest  # noqa: E402
+from unittest.mock import patch  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+from fastapi import FastAPI  # noqa: E402
 
-from routers.chat import router
-from schemas import ChatResponse, SourceInfo
+from routers.chat import router  # noqa: E402
+from schemas import ChatResponse, SourceInfo  # noqa: E402
 
 
 @pytest.fixture

--- a/backend/tests/test_rag_service.py
+++ b/backend/tests/test_rag_service.py
@@ -5,10 +5,7 @@ import os
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
-import pytest
-from unittest.mock import MagicMock, patch
-
-from schemas import ChatResponse, SourceInfo
+from unittest.mock import MagicMock, patch  # noqa: E402
 
 
 class TestAskNoResults:


### PR DESCRIPTION
## 変更概要
- E203: スライス記法の空白を修正
- E402: importにnoqaコメントを追加
- F401: 未使用importを削除