### PR TITLE
fix: vector_store.pyの型アノテーション実行時エラーを修正

### DIFF
--- a/backend/services/vector_store.py
+++ b/backend/services/vector_store.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 
 import chromadb


### PR DESCRIPTION
## 概要
- `services/vector_store.py:9` で `chromadb.PersistentClient | None` の union type 構文が実行時に `TypeError` を起こしていた
- `from __future__ import annotations` を追加し、型アノテーションを遅延評価にすることで解決