### PR TITLE
DOCXファイル形式のサポートを追加

### DIFF
--- a/backend/routers/documents.py
+++ b/backend/routers/documents.py
@@ -20,7 +20,7 @@ MAX_FILE_SIZE = 10 * 1024 * 1024  # 10MB
 
 router = APIRouter(prefix="/api/documents", tags=["documents"])
 
-ALLOWED_EXTENSIONS = {"pdf", "csv", "txt", "md", "markdown"}
+ALLOWED_EXTENSIONS = {"pdf", "docx", "csv", "txt", "md", "markdown"}
 
 
 @router.post("/upload", response_model=DocumentResponse)

--- a/backend/services/document_processor.py
+++ b/backend/services/document_processor.py
@@ -3,6 +3,7 @@ import io
 import re
 
 import chardet
+import docx
 import PyPDF2
 
 from config import settings
@@ -14,12 +15,24 @@ def extract_text(file_bytes: bytes, filename: str) -> str:
 
     if ext == "pdf":
         return _extract_pdf(file_bytes)
+    elif ext == "docx":
+        return _extract_docx(file_bytes)
     elif ext == "csv":
         return _extract_csv(file_bytes)
     elif ext in ("txt", "md", "markdown"):
         return _extract_text(file_bytes)
     else:
         raise ValueError(f"未対応のファイル形式です: {ext}")
+
+
+def _extract_docx(file_bytes: bytes) -> str:
+    document = docx.Document(io.BytesIO(file_bytes))
+    texts = []
+    for para in document.paragraphs:
+        text = para.text.strip()
+        if text:
+            texts.append(text)
+    return "\n".join(texts)
 
 
 def _extract_pdf(file_bytes: bytes) -> str:

--- a/backend/tests/test_document_processor.py
+++ b/backend/tests/test_document_processor.py
@@ -107,7 +107,21 @@ class TestExtractText:
         assert "名前" in result
         assert "田中" in result
 
+    def test_extract_docx_file(self):
+        """docxファイルからテキストを抽出できる"""
+        from docx import Document
+        import io
+        doc = Document()
+        doc.add_paragraph("DOCXテスト文書です。")
+        doc.add_paragraph("2番目の段落です。")
+        buf = io.BytesIO()
+        doc.save(buf)
+        file_bytes = buf.getvalue()
+        result = self.extract_text(file_bytes, "test.docx")
+        assert "DOCXテスト文書" in result
+        assert "2番目の段落" in result
+
     def test_unsupported_extension_raises_error(self):
         """未対応の拡張子はValueErrorを発生させる"""
         with pytest.raises(ValueError, match="未対応"):
-            self.extract_text(b"content", "test.docx")
+            self.extract_text(b"content", "test.xlsx")


### PR DESCRIPTION
## 変更概要
- `services/document_processor.py`: `_extract_docx()`関数を追加し、python-docxで段落テキストを抽出
- `routers/documents.py`: ALLOWED_EXTENSIONSにdocxを追加
- `tests/test_document_processor.py`: DOCXファイル抽出テストを追加、未対応テストをxlsxに変更

## 対応Issue
Closes #17

## 動作確認手順
1. `flake8 . --max-line-length=120 --exclude=__pycache__,.git` でlintパスを確認
2. `pytest tests/ -v` で全38テスト通過を確認
3. DOCXファイルをアップロードしてテキスト抽出が成功することを確認