### PR TITLE
重複ドキュメント検知機能の追加とテスト

### DIFF
--- a/backend/routers/documents.py
+++ b/backend/routers/documents.py
@@ -24,7 +24,11 @@ ALLOWED_EXTENSIONS = {"pdf", "docx", "csv", "txt", "md", "markdown"}
 
 
 @router.post("/upload", response_model=DocumentResponse)
-async def upload_document(file: UploadFile, db: AsyncSession = Depends(get_db)):
+async def upload_document(
+    file: UploadFile,
+    force: bool = False,
+    db: AsyncSession = Depends(get_db),
+):
     """文書をアップロードし、チャンク分割・Embedding・ベクトルDB保存を行う"""
     if not file.filename:
         raise HTTPException(status_code=400, detail="ファイル名がありません")
@@ -44,6 +48,24 @@ async def upload_document(file: UploadFile, db: AsyncSession = Depends(get_db)):
             status_code=400,
             detail=f"ファイルサイズが上限（{MAX_FILE_SIZE // (1024 * 1024)}MB）を超えています",
         )
+
+    # 重複ドキュメント検知
+    if not force:
+        existing = await db.execute(
+            select(Document).where(
+                Document.filename == file.filename,
+                Document.status == "ready",
+            )
+        )
+        if existing.scalar_one_or_none() is not None:
+            logger.warning(
+                "重複ドキュメント検知: filename=%s", file.filename,
+            )
+            raise HTTPException(
+                status_code=409,
+                detail=f"同名のファイル '{file.filename}' は既に登録済みです。"
+                "上書きする場合は force=true を指定してください。",
+            )
 
     # DBにメタデータ保存
     doc = Document(

--- a/backend/tests/test_documents_router.py
+++ b/backend/tests/test_documents_router.py
@@ -1,0 +1,196 @@
+"""routers/documents.py のエンドポイントテスト"""
+
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from unittest.mock import patch  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+from fastapi import FastAPI  # noqa: E402
+from io import BytesIO  # noqa: E402
+
+from routers.documents import router  # noqa: E402
+
+
+class FakeDocument:
+    """テスト用のDocumentモデル代替"""
+    def __init__(self, **kwargs):
+        self.id = kwargs.get("id", 1)
+        self.filename = kwargs.get("filename", "test.txt")
+        self.file_type = kwargs.get("file_type", "txt")
+        self.file_size = kwargs.get("file_size", 100)
+        self.chunk_count = kwargs.get("chunk_count", 0)
+        self.status = kwargs.get("status", "processing")
+        self.uploaded_at = kwargs.get("uploaded_at", "2026-01-01T00:00:00")
+
+
+class FakeScalarResult:
+    """scalar_one_or_none の返り値を模倣"""
+    def __init__(self, value=None):
+        self._value = value
+
+    def scalar_one_or_none(self):
+        return self._value
+
+    def scalars(self):
+        return self
+
+    def all(self):
+        return self._value if self._value else []
+
+    def one(self):
+        return self._value
+
+
+class FakeDBSession:
+    """テスト用の非同期DBセッション"""
+    def __init__(self, existing_doc=None):
+        self._existing_doc = existing_doc
+        self._added = []
+        self._deleted = []
+        self._committed = False
+
+    async def execute(self, stmt):
+        return FakeScalarResult(self._existing_doc)
+
+    def add(self, obj):
+        self._added.append(obj)
+
+    async def commit(self):
+        self._committed = True
+
+    async def refresh(self, obj):
+        if not hasattr(obj, "id") or obj.id is None:
+            obj.id = 1
+        if not hasattr(obj, "uploaded_at") or obj.uploaded_at is None:
+            obj.uploaded_at = "2026-01-01T00:00:00"
+
+    async def delete(self, obj):
+        self._deleted.append(obj)
+
+
+def create_test_app(existing_doc=None):
+    """テスト用アプリケーション生成"""
+    test_app = FastAPI()
+    test_app.include_router(router)
+
+    db_session = FakeDBSession(existing_doc=existing_doc)
+
+    async def override_get_db():
+        yield db_session
+
+    from database import get_db
+    test_app.dependency_overrides[get_db] = override_get_db
+
+    return test_app, db_session
+
+
+class TestUploadDuplicateDetection:
+    """重複ドキュメント検知のテスト"""
+
+    def test_duplicate_filename_returns_409(self):
+        """同名ファイルが既に存在する場合、409を返す"""
+        existing = FakeDocument(filename="test.txt", status="ready")
+        app, _ = create_test_app(existing_doc=existing)
+        client = TestClient(app)
+
+        file_content = b"test content"
+        response = client.post(
+            "/api/documents/upload",
+            files={"file": ("test.txt", BytesIO(file_content), "text/plain")},
+        )
+
+        assert response.status_code == 409
+        data = response.json()
+        assert "既に登録済み" in data["detail"]
+
+    @patch("routers.documents.generate_embeddings")
+    @patch("routers.documents.add_chunks")
+    @patch("routers.documents.extract_text")
+    @patch("routers.documents.split_into_chunks")
+    def test_duplicate_with_force_allows_upload(
+        self, mock_split, mock_extract, mock_add, mock_embed
+    ):
+        """force=trueの場合、重複でもアップロードを許可する"""
+        existing = FakeDocument(filename="test.txt", status="ready")
+        app, _ = create_test_app(existing_doc=existing)
+        client = TestClient(app)
+
+        mock_extract.return_value = "テストコンテンツ"
+        mock_split.return_value = ["チャンク1"]
+        mock_embed.return_value = [[0.1] * 10]
+
+        file_content = b"test content"
+        response = client.post(
+            "/api/documents/upload?force=true",
+            files={"file": ("test.txt", BytesIO(file_content), "text/plain")},
+        )
+
+        assert response.status_code == 200
+
+    @patch("routers.documents.generate_embeddings")
+    @patch("routers.documents.add_chunks")
+    @patch("routers.documents.extract_text")
+    @patch("routers.documents.split_into_chunks")
+    def test_new_filename_allows_upload(
+        self, mock_split, mock_extract, mock_add, mock_embed
+    ):
+        """新規ファイル名の場合、正常にアップロードできる"""
+        app, _ = create_test_app(existing_doc=None)
+        client = TestClient(app)
+
+        mock_extract.return_value = "テストコンテンツ"
+        mock_split.return_value = ["チャンク1"]
+        mock_embed.return_value = [[0.1] * 10]
+
+        file_content = b"new document content"
+        response = client.post(
+            "/api/documents/upload",
+            files={"file": ("new_doc.txt", BytesIO(file_content), "text/plain")},
+        )
+
+        assert response.status_code == 200
+
+
+class TestUploadValidation:
+    """アップロードバリデーションのテスト"""
+
+    def test_no_filename_returns_error(self):
+        """ファイル名なしの場合にエラーを返す"""
+        app, _ = create_test_app()
+        client = TestClient(app)
+
+        response = client.post(
+            "/api/documents/upload",
+            files={"file": ("", BytesIO(b"content"), "text/plain")},
+        )
+
+        assert response.status_code in (400, 422)
+
+    def test_unsupported_extension_returns_400(self):
+        """未対応の拡張子の場合に400を返す"""
+        app, _ = create_test_app()
+        client = TestClient(app)
+
+        response = client.post(
+            "/api/documents/upload",
+            files={"file": ("test.exe", BytesIO(b"content"), "application/octet-stream")},
+        )
+
+        assert response.status_code == 400
+        assert "未対応" in response.json()["detail"]
+
+    def test_file_too_large_returns_400(self):
+        """ファイルサイズ上限超過で400を返す"""
+        app, _ = create_test_app()
+        client = TestClient(app)
+
+        large_content = b"x" * (10 * 1024 * 1024 + 1)
+        response = client.post(
+            "/api/documents/upload",
+            files={"file": ("large.txt", BytesIO(large_content), "text/plain")},
+        )
+
+        assert response.status_code == 400
+        assert "上限" in response.json()["detail"]


### PR DESCRIPTION
## 変更概要

- アップロード時に同名ファイル（status=ready）の重複検知を追加（409 Conflict）
- `force=true` クエリパラメータによる強制アップロード機能を追加
- ドキュメントルーターのユニットテスト6件を新規追加
  - 重複検知テスト（409返却、force=trueでバイパス、新規ファイルは正常）
  - バリデーションテスト（ファイル名なし、未対応拡張子、サイズ超過）
- flake8 lint + pytest 全43件パス確認済み

Closes #19

## 動作確認手順

1. `cd backend && python -m pytest tests/ -v` で全テストがパスすることを確認
2. `flake8 . --max-line-length=120` でlintエラーがないことを確認