### PR TITLE
ドキュメント一覧APIのページネーション追加・MAX_FILE_SIZEの設定外部化

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -8,6 +8,7 @@ class Settings(BaseSettings):
     chroma_persist_dir: str = "./chroma_data"
     database_url: str = "sqlite+aiosqlite:///./knowledge.db"
     upload_dir: str = "./uploads"
+    max_file_size: int = 10 * 1024 * 1024  # 10MB
     chunk_size: int = 500
     chunk_overlap: int = 50
     max_retrieval_results: int = 5

--- a/backend/routers/documents.py
+++ b/backend/routers/documents.py
@@ -9,14 +9,13 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from config import settings
 from database import get_db
 from models import Document
-from schemas import DocumentResponse, DocumentStats, FileTypeCount
+from schemas import DocumentResponse, DocumentStats, FileTypeCount, PaginatedDocumentResponse
 from services.document_processor import extract_text, split_into_chunks
 from services.embedding_service import generate_embeddings
 from services.vector_store import add_chunks, delete_by_document_id
 
 logger = logging.getLogger(__name__)
 
-MAX_FILE_SIZE = 10 * 1024 * 1024  # 10MB
 
 router = APIRouter(prefix="/api/documents", tags=["documents"])
 
@@ -43,10 +42,10 @@ async def upload_document(
     file_bytes = await file.read()
     file_size = len(file_bytes)
 
-    if file_size > MAX_FILE_SIZE:
+    if file_size > settings.max_file_size:
         raise HTTPException(
             status_code=400,
-            detail=f"ファイルサイズが上限（{MAX_FILE_SIZE // (1024 * 1024)}MB）を超えています",
+            detail=f"ファイルサイズが上限（{settings.max_file_size // (1024 * 1024)}MB）を超えています",
         )
 
     # 重複ドキュメント検知
@@ -113,13 +112,35 @@ async def upload_document(
     return doc
 
 
-@router.get("", response_model=list[DocumentResponse])
-async def list_documents(db: AsyncSession = Depends(get_db)):
-    """登録済み文書一覧を取得する"""
+@router.get("", response_model=PaginatedDocumentResponse)
+async def list_documents(
+    offset: int = 0,
+    limit: int = 20,
+    db: AsyncSession = Depends(get_db),
+):
+    """登録済み文書一覧を取得する（ページネーション対応）"""
+    if limit > 100:
+        limit = 100
+    if offset < 0:
+        offset = 0
+
+    total_result = await db.execute(select(func.count(Document.id)))
+    total = int(total_result.scalar_one())
+
     result = await db.execute(
-        select(Document).order_by(Document.uploaded_at.desc())
+        select(Document)
+        .order_by(Document.uploaded_at.desc())
+        .offset(offset)
+        .limit(limit)
     )
-    return result.scalars().all()
+    items = result.scalars().all()
+
+    return PaginatedDocumentResponse(
+        items=items,
+        total=total,
+        offset=offset,
+        limit=limit,
+    )
 
 
 @router.get("/stats", response_model=DocumentStats)

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -40,6 +40,13 @@ class ChatResponse(BaseModel):
     confidence: str  # "high" | "medium" | "low" | "unknown"
 
 
+class PaginatedDocumentResponse(BaseModel):
+    items: list[DocumentResponse]
+    total: int
+    offset: int
+    limit: int
+
+
 class FileTypeCount(BaseModel):
     file_type: str
     count: int

--- a/backend/tests/test_documents_router.py
+++ b/backend/tests/test_documents_router.py
@@ -33,6 +33,9 @@ class FakeScalarResult:
     def scalar_one_or_none(self):
         return self._value
 
+    def scalar_one(self):
+        return self._value if self._value is not None else 0
+
     def scalars(self):
         return self
 
@@ -186,7 +189,8 @@ class TestUploadValidation:
         app, _ = create_test_app()
         client = TestClient(app)
 
-        large_content = b"x" * (10 * 1024 * 1024 + 1)
+        from config import settings
+        large_content = b"x" * (settings.max_file_size + 1)
         response = client.post(
             "/api/documents/upload",
             files={"file": ("large.txt", BytesIO(large_content), "text/plain")},
@@ -194,3 +198,43 @@ class TestUploadValidation:
 
         assert response.status_code == 400
         assert "上限" in response.json()["detail"]
+
+
+class TestListDocumentsPagination:
+    """ドキュメント一覧ページネーションのテスト"""
+
+    def test_list_returns_paginated_response(self):
+        """ページネーション形式で一覧を返す"""
+        app, _ = create_test_app()
+        client = TestClient(app)
+
+        response = client.get("/api/documents")
+        assert response.status_code == 200
+        data = response.json()
+        assert "items" in data
+        assert "total" in data
+        assert "offset" in data
+        assert "limit" in data
+        assert data["offset"] == 0
+        assert data["limit"] == 20
+
+    def test_list_with_custom_offset_and_limit(self):
+        """offset/limitパラメータが反映される"""
+        app, _ = create_test_app()
+        client = TestClient(app)
+
+        response = client.get("/api/documents?offset=5&limit=10")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["offset"] == 5
+        assert data["limit"] == 10
+
+    def test_list_limit_capped_at_100(self):
+        """limitの上限は100"""
+        app, _ = create_test_app()
+        client = TestClient(app)
+
+        response = client.get("/api/documents?limit=200")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["limit"] == 100


### PR DESCRIPTION
## 変更概要\n\n- `GET /api/documents` に `offset` / `limit` クエリパラメータによるページネーションを追加\n- レスポンスを `PaginatedDocumentResponse` 形式（`items`, `total`, `offset`, `limit`）に変更\n- `limit` の上限を100に制限（過大なリクエスト防止）\n- `MAX_FILE_SIZE` をハードコード定数から `config.py` の `Settings.max_file_size` に移動\n- 環境変数 `MAX_FILE_SIZE` でファイルサイズ上限を変更可能に\n- ページネーション関連のユニットテスト3件を追加\n\nCloses #23\n\n## 動作確認手順\n1. `docker-compose up` で起動\n2. `GET /api/documents` → `items`, `total`, `offset`, `limit` を含むレスポンス確認\n3. `GET /api/documents?offset=0&limit=5` → 5件以下返却確認\n4. `GET /api/documents?limit=200` → `limit` が100に制限されていることを確認\n5. `MAX_FILE_SIZE=5242880` を `.env` に設定し、5MB超ファイルがアップロード拒否されること確認"