### PR TITLE
feat: ドキュメント一覧APIにファイル名検索フィルタを追加

### DIFF
--- a/backend/routers/documents.py
+++ b/backend/routers/documents.py
@@ -132,19 +132,28 @@ async def upload_document(
 async def list_documents(
     offset: int = 0,
     limit: int = 20,
+    search: str = "",
     db: AsyncSession = Depends(get_db),
 ):
-    """登録済み文書一覧を取得する（ページネーション対応）"""
+    """登録済み文書一覧を取得する（ページネーション・検索対応）"""
     if limit > 100:
         limit = 100
     if offset < 0:
         offset = 0
 
-    total_result = await db.execute(select(func.count(Document.id)))
+    base_query = select(Document)
+    count_query = select(func.count(Document.id))
+
+    if search.strip():
+        pattern = f"%{search.strip()}%"
+        base_query = base_query.where(Document.filename.ilike(pattern))
+        count_query = count_query.where(Document.filename.ilike(pattern))
+
+    total_result = await db.execute(count_query)
     total = int(total_result.scalar_one())
 
     result = await db.execute(
-        select(Document)
+        base_query
         .order_by(Document.uploaded_at.desc())
         .offset(offset)
         .limit(limit)

--- a/backend/tests/test_documents_router.py
+++ b/backend/tests/test_documents_router.py
@@ -287,6 +287,48 @@ class TestListDocumentsPagination:
         data = response.json()
         assert data["offset"] == 0
 
+    def test_list_with_search_parameter(self):
+        """searchパラメータ付きでリクエストが正常に処理される"""
+        app, _ = create_test_app()
+        client = TestClient(app)
+
+        response = client.get("/api/documents?search=report")
+        assert response.status_code == 200
+        data = response.json()
+        assert "items" in data
+        assert "total" in data
+
+    def test_list_with_empty_search(self):
+        """空のsearchパラメータでも正常動作する"""
+        app, _ = create_test_app()
+        client = TestClient(app)
+
+        response = client.get("/api/documents?search=")
+        assert response.status_code == 200
+        data = response.json()
+        assert "items" in data
+
+    def test_list_with_search_and_pagination(self):
+        """searchとページネーションパラメータの併用が正常動作する"""
+        app, _ = create_test_app()
+        client = TestClient(app)
+
+        response = client.get("/api/documents?search=test&offset=0&limit=5")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["offset"] == 0
+        assert data["limit"] == 5
+
+    def test_list_with_whitespace_search(self):
+        """空白のみのsearchパラメータは通常の一覧と同等に動作する"""
+        app, _ = create_test_app()
+        client = TestClient(app)
+
+        response = client.get("/api/documents?search=%20%20")
+        assert response.status_code == 200
+        data = response.json()
+        assert "items" in data
+
 
 def create_stats_test_app(stats_tuple, type_rows):
     """統計テスト用アプリケーション生成"""


### PR DESCRIPTION
## 変更概要
- `GET /api/documents` に `search` クエリパラメータを追加
- ファイル名に対するilike（大文字小文字区別なし）部分一致検索を実装
- 空白のみの検索文字列は無視して通常の一覧を返却
- 対応するユニットテスト4件を追加

Closes #29

## 動作確認手順
1. `GET /api/documents?search=report` で該当ファイルが絞り込まれること
2. `GET /api/documents?search=&offset=0&limit=5` でページネーションとの併用が正常動作すること
3. `pytest tests/test_documents_router.py -v` で全テストがパスすること