### PR TITLE
fix: アップロード失敗時のエラーメッセージから内部情報を除去

### DIFF
--- a/backend/routers/documents.py
+++ b/backend/routers/documents.py
@@ -123,7 +123,10 @@ async def upload_document(
         logger.error("文書処理に失敗 (doc_id=%s): %s", doc.id, e, exc_info=True)
         doc.status = "error"
         await db.commit()
-        raise HTTPException(status_code=500, detail=f"処理に失敗しました: {str(e)}")
+        raise HTTPException(
+            status_code=500,
+            detail="文書の処理に失敗��ました。ファイルの形式をご確認のうえ再度お試しく���さい。",
+        )
 
     return doc
 


### PR DESCRIPTION
## 変更概要
- `backend/routers/documents.py`のアップロードエンドポイントで、文書処理失敗時のHTTPExceptionの`detail`に`str(e)`で内部エラー詳細が含まれていた問題を修正
- 汎用的なエラーメッセージに変更し、内部情報の漏洩を防止
- 内部エラーの詳細は既存の`logger.error`でログ出力済み

Closes #33

## 動作確認
- `flake8`（critical errors + max-line-length=120）パス
- `pytest tests/ -v` 全76テストパス